### PR TITLE
Combine both permapod controllers into one

### DIFF
--- a/bash-permapod-controller/controller-unified.sh
+++ b/bash-permapod-controller/controller-unified.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+echo "Controller starting"
+
+# Kill the whole process group as we want to kill
+# both background jobs when terminating this script.
+# Note the nested `trap` resets the script's SIGTERM
+# response to the default `kill` behaviour; we don't
+# want to cause a `trap` inception. The `kill -- -$$`
+# sends a SIGTERM to the whole process group, thus
+# killing all descendants, see:
+# https://stackoverflow.com/a/2173421/16406860
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
+
+reconcile_ns() {
+  local ns=$1
+  echo "Reconciling namespace: $ns"
+  kubectl get pod -n $ns permapod >/dev/null 2>&1
+  return_value=$?
+
+  if [ $return_value -eq 1 ]; then
+    echo "Permapod does not exist, creating pod"
+    kubectl run permapod -n $ns --image ubuntu -- sleep 10000
+  else
+    echo "Permapod EXISTS, doing nothing"
+  fi
+}
+
+# In bash all commands in a pipeline execute in a subshell, so no need to
+# wrap this command in parenthesis. Appending the ampersand will turn it
+# into a background process.
+kubectl get namespaces -w -o=jsonpath='{.metadata.name}{"\n"}' | while IFS= read -r ns; do
+  reconcile_ns "$ns"
+done &
+
+kubectl get pods -A -w -o=jsonpath='{.metadata.namespace}{"\n"}' | while IFS= read -r ns; do
+  reconcile_ns "$ns"
+done &
+
+# Wait forever, or until we receive a Term signal.
+# If we don't wait here this script finishes and
+# there is no way to trap the exit code and act on it.
+wait

--- a/bash-permapod-controller/controller.sh
+++ b/bash-permapod-controller/controller.sh
@@ -18,7 +18,7 @@ reconcile () {
     fi
 }
 
-# The function needs to be exported so that is can be called with xargs.
+# The function needs to be exported so that it can be called with xargs.
 export -f reconcile
 
 kubectl get namespaces -w -o=jsonpath='{.metadata.name}{"\n"}' | xargs -L1 bash -c 'reconcile "$@"' _


### PR DESCRIPTION
Instead of running the two permapod controllers as two different scripts, I combine them into one by running the two reconciliation processes as background processes. This means I do have to add some logic to make sure both processes are killed when stopping the script. The first part is trapping the term signals and killing the process group as a whole, the second part is keeping the script running, essentially waiting for both processes to finish (which they never will).

I did not like the whole "export a function", so instead I'm using a `while` loop to iterate over all namespace updates.

I saw @celsoRodrigues opened a similar PR, but given he used a slightly different approach (especially regarding exporting the `reconcile` function) I still also wanted to give you mine 😄 